### PR TITLE
[tailscale-subnet-router] Support additional environment variables

### DIFF
--- a/charts/tailscale-subnet-router/Chart.yaml
+++ b/charts/tailscale-subnet-router/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tailscale-subnet-router
 description: Deploy a Tailscale subnet router on Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "v1.34.1"
 home: https://github.com/gtaylor/helm-charts/charts/tailscale-subnet-router
 sources:

--- a/charts/tailscale-subnet-router/README.md
+++ b/charts/tailscale-subnet-router/README.md
@@ -82,6 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | tailscale.auth.secretName | string | `"tailscale-subnet-router-secrets"` | The name of the secret containing a Tailscale auth key |
 | tailscale.routes | list | `["10.96.0.0/12","10.244.0.0/16"]` | Routes for the subnet router to publish |
 | tailscale.state.secretName | string | `"tailscale-subnet-router-state"` | The secret that the subnet router will store its state in |
+| tailscale.extraEnv | list(object) | `[]` | Additional environment variables to include in the StatefulSet |
 | tolerations | list | `[]` | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for pod assignment |
 | volumeMounts | list | `[]` | Additional volumes to add to mount to the primary container |
 | volumes | list | `[]` | Additional volumes to add to the pod |

--- a/charts/tailscale-subnet-router/templates/statefulset.yaml
+++ b/charts/tailscale-subnet-router/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "tailscale-subnet-router.fullname" . }}
+        - name: {{ include "tailscale-subnet-router.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/tailscale-subnet-router/templates/statefulset.yaml
+++ b/charts/tailscale-subnet-router/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ include "tailscale-subnet-router.fullname" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -46,6 +46,9 @@ spec:
                   key: {{ .Values.tailscale.auth.secretKey }}
             - name: TS_ROUTES
               value: {{ join "," .Values.tailscale.routes|quote }}
+          {{- if .Values.tailscale.extraEnv }}
+          {{- tpl (.Values.tailscale.extraEnv | toYaml) . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           resources: {{ toYaml . | nindent 16 }}
           {{- end }}

--- a/charts/tailscale-subnet-router/values.yaml
+++ b/charts/tailscale-subnet-router/values.yaml
@@ -31,6 +31,13 @@ tailscale:
     # Default pod CIDR
     - "10.244.0.0/16"
 
+  # -- Additional environment values
+  extraEnv: []
+  #   - name: TS_EXTRA_ARGS
+  #     value: "--advertise-exit-node"
+  #   - name: ARG_WITH_TPL
+  #     value: "{{ .Chart.Name }}"
+
 # -- The service account to create or attach
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
This PR adds the ability to include additional environment variables in the `StatefulSet`. This can be used to provide `TS_EXTRA_ARGS` like `--advertise-exit-node`, but accomplishes it in a generic/extensible fashion. Additionally, it uses `tpl` to handle interpolation.

The commented values yield the following rendered env vars:
```
          env:
            - name: TS_KUBE_SECRET
              value: tailscale-subnet-router-state
            - name: TS_USERSPACE
              value: "true"
            - name: TS_AUTH_KEY
              valueFrom:
                secretKeyRef:
                  name: tailscale-subnet-router-secrets
                  key: AUTH_KEY
            - name: TS_ROUTES
              value: "10.96.0.0/12,10.244.0.0/16"
            - name: TS_EXTRA_ARGS
              value: --advertise-exit-node
            - name: ARG_WITH_TPL
              value: 'tailscale-subnet-router'
```